### PR TITLE
Extract '_parse_ladder_operator' from FermionOperator.__init__

### DIFF
--- a/src/fermilib/ops/_fermion_operator.py
+++ b/src/fermilib/ops/_fermion_operator.py
@@ -137,18 +137,22 @@ def normal_ordered(fermion_operator):
 def _parse_ladder_operator(ladder_operator_text):
     """
     Args:
-        ladder_operator_text (str): A ladder operator term like '4' or '5^'.
+        ladder_operator_text (str):
+            A ladder operator term like '4' or '5^', or an invalid string.
     Returns:
         tuple[int, int]: The mode then raise-vs-lower.
+    Raises:
+        FermionOperatorError: Given invalid text that doesn't match /\d+^?/ .
     """
     inverted = 1 if ladder_operator_text.endswith('^') else 0
+    mode_text = ladder_operator_text[:-1] if inverted else ladder_operator_text
 
     try:
-        mode = int(ladder_operator_text[:-inverted])
+        mode = int(mode_text)
         if mode < 0:
             raise ValueError()  # Merge with not-an-int failure case.
     except ValueError:
-        raise ValueError(
+        raise FermionOperatorError(
             "Invalid ladder operator term '{}'.".format(ladder_operator_text))
 
     return mode, inverted

--- a/src/fermilib/ops/_fermion_operator.py
+++ b/src/fermilib/ops/_fermion_operator.py
@@ -134,6 +134,26 @@ def normal_ordered(fermion_operator):
     return ordered_operator
 
 
+def _parse_ladder_operator(ladder_operator_text):
+    """
+    Args:
+        ladder_operator_text (str): A ladder operator term like '4' or '5^'.
+    Returns:
+        tuple[int, int]: The mode then raise-vs-lower.
+    """
+    inverted = 1 if ladder_operator_text.endswith('^') else 0
+
+    try:
+        mode = int(ladder_operator_text[:-inverted])
+        if mode < 0:
+            raise ValueError()  # Merge with not-an-int failure case.
+    except ValueError:
+        raise ValueError(
+            "Invalid ladder operator term '{}'.".format(ladder_operator_text))
+
+    return mode, inverted
+
+
 class FermionOperator(object):
     """FermionOperator stores a sum of products of fermionic ladder operators.
 
@@ -212,16 +232,8 @@ class FermionOperator(object):
 
         # String input.
         if isinstance(term, str):
-            ladder_operators = []
-            for ladder_operator in term.split():
-                if ladder_operator[-1] == '^':
-                    ladder_operators.append((int(ladder_operator[:-1]), 1))
-                else:
-                    try:
-                        ladder_operators.append((int(ladder_operator), 0))
-                    except ValueError:
-                        raise ValueError(
-                            'Invalid action provided to FermionTerm.')
+            ladder_operators = tuple(_parse_ladder_operator(e)
+                                     for e in term.split())
             self.terms[tuple(ladder_operators)] = coefficient
 
         # Tuple input.

--- a/src/fermilib/ops/_fermion_operator_test.py
+++ b/src/fermilib/ops/_fermion_operator_test.py
@@ -62,21 +62,25 @@ class FermionOperatorTest(unittest.TestCase):
         self.assertIn(correct, fermion_op.terms)
         self.assertEqual(fermion_op.terms[correct], -1.0)
 
+    def test_merges_multiple_whitespace(self):
+        fermion_op = FermionOperator('        \n ')
+        self.assertEqual(fermion_op.terms, {(): 1})
+
     def test_init_str_identity(self):
         fermion_op = FermionOperator('')
         self.assertIn((), fermion_op.terms)
 
     def test_init_bad_term(self):
         with self.assertRaises(ValueError):
-            fermion_op = FermionOperator(list())
+            _ = FermionOperator(list())
 
     def test_init_bad_coefficient(self):
         with self.assertRaises(ValueError):
-            fermion_op = FermionOperator('0^', "0.5")
+            _ = FermionOperator('0^', "0.5")
 
     def test_init_bad_action_str(self):
-        with self.assertRaises(ValueError):
-            fermion_op = FermionOperator('0-')
+        with self.assertRaises(FermionOperatorError):
+            _ = FermionOperator('0-')
 
     def test_init_bad_action_tuple(self):
         with self.assertRaises(ValueError):
@@ -84,15 +88,15 @@ class FermionOperatorTest(unittest.TestCase):
 
     def test_init_bad_tuple(self):
         with self.assertRaises(ValueError):
-            fermion_op = FermionOperator(((0, 1, 1),))
+            _ = FermionOperator(((0, 1, 1),))
 
     def test_init_bad_str(self):
-        with self.assertRaises(ValueError):
-            fermion_op = FermionOperator('^')
+        with self.assertRaises(FermionOperatorError):
+            _ = FermionOperator('^')
 
     def test_init_bad_mode_num(self):
         with self.assertRaises(FermionOperatorError):
-            fermion_op = FermionOperator('-1^')
+            _ = FermionOperator('-1^')
 
     def test_FermionOperator(self):
         op = FermionOperator((), 3.)


### PR DESCRIPTION
Mostly just a simple method extraction.

There was also an inconsistency in how bad strings were handled (some produced ValueError, some produced FermionOperatorError). I modified the code and tests so that both cause FermionOperatorError.

Also I fixed some nearby 'unused variable' warnings.