### PR TITLE
Nested loop compression and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,105 @@
-*.pyc
-__pycache__/
 .DS_Store
-.ipynb_checkpoints/
 *lastfailed
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
 *coverage
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/src/fermilib/ops/_interaction_operator.py
+++ b/src/fermilib/ops/_interaction_operator.py
@@ -90,19 +90,16 @@ class InteractionOperator(InteractionTensor):
 
         # Two-body terms.
         record_map = {}
-        for p in range(self.n_qubits):
-            for q in range(self.n_qubits):
-                for r in range(self.n_qubits):
-                    for s in range(self.n_qubits):
-                        if self.two_body_tensor[p, q, r, s] and \
-                           (p, q, r, s) not in record_map:
-                            yield [p, q, r, s]
-                            record_map[(p, q, r, s)] = []
-                            record_map[(s, r, q, p)] = []
-                            record_map[(q, p, s, r)] = []
-                            record_map[(r, s, p, q)] = []
-                            if not complex_valued:
-                                record_map[(p, s, r, q)] = []
-                                record_map[(s, p, q, r)] = []
-                                record_map[(q, r, s, p)] = []
-                                record_map[(r, q, p, s)] = []
+        for p, q, r, s in itertools.product(range(self.n_qubits), repeat=4):
+            if self.two_body_tensor[p, q, r, s] and \
+               (p, q, r, s) not in record_map:
+                yield [p, q, r, s]
+                record_map[(p, q, r, s)] = []
+                record_map[(s, r, q, p)] = []
+                record_map[(q, p, s, r)] = []
+                record_map[(r, s, p, q)] = []
+                if not complex_valued:
+                    record_map[(p, s, r, q)] = []
+                    record_map[(s, p, q, r)] = []
+                    record_map[(q, r, s, p)] = []
+                    record_map[(r, q, p, s)] = []


### PR DESCRIPTION
Nested loops with equivalent ranges can be represented in one line using
the itertools product generator.  Easier to read/reason about.

gitignore is expanded to include the common ignored files for python libraries.
Git will now ignore files associated with installation egg, build, etc when
files are staged for commits.