### PR TITLE
Broadening gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,72 @@
-*.pyc
-__pycache__/
 .DS_Store
-.ipynb_checkpoints/
 *lastfailed
 *coverage
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# mkdocs documentation
+/site


### PR DESCRIPTION
Gitignore did not flag installation files and intermediate files such as
checkpoints for ipython notebooks and built sphinx documentation.

Update to the gitignore will prevent developers commiting the checkpoint files
, environment files, sphinx documentation, etc.