### PR TITLE
Minor fixes to InteractionRDM

### DIFF
--- a/src/fermilib/ops/_interaction_rdm.py
+++ b/src/fermilib/ops/_interaction_rdm.py
@@ -35,7 +35,6 @@ class InteractionRDM(InteractionTensor):
         one_body_tensor: The expectation values <a^\dagger_p a_q>.
         two_body_tensor: The expectation values
             <a^\dagger_p a^\dagger_q a_r a_s>.
-        n_qubits: An int giving the number of qubits.
     """
 
     def __init__(self, one_body_tensor, two_body_tensor):
@@ -106,7 +105,7 @@ class InteractionRDM(InteractionTensor):
 
             # Map qubits back to fermions.
             reversed_fermion_operators = reverse_jordan_wigner(
-                QubitOperator(qubit_term), self.n_qubits)
+                QubitOperator(qubit_term))
             reversed_fermion_operators = normal_ordered(
                 reversed_fermion_operators)
 

--- a/src/fermilib/ops/_interaction_rdm.py
+++ b/src/fermilib/ops/_interaction_rdm.py
@@ -70,9 +70,11 @@ class InteractionRDM(InteractionTensor):
             InteractionRDMError: Invalid operator provided.
         """
         if isinstance(operator, QubitOperator):
-            expectation_value = 0.
-            for qubit_term in operator:
-                expectation += qubit_term_expectation(self, qubit_term)
+            expectation_op = self.get_qubit_expectations(operator)
+            expectation = 0.0
+            for qubit_term in operator.terms:
+                expectation += (operator.terms[qubit_term] *
+                                expectation_op.terms[qubit_term])
         elif isinstance(operator, InteractionOperator):
             expectation = operator.constant
             expectation += numpy.sum(self.one_body_tensor *
@@ -99,7 +101,6 @@ class InteractionRDM(InteractionTensor):
         """
         from fermilib.transforms import reverse_jordan_wigner
         qubit_operator_expectations = copy.deepcopy(qubit_operator)
-        del qubit_operator_expectations.terms[()]
         for qubit_term in qubit_operator_expectations.terms:
             expectation = 0.
 

--- a/src/fermilib/ops/_interaction_rdm_test.py
+++ b/src/fermilib/ops/_interaction_rdm_test.py
@@ -39,7 +39,7 @@ class InteractionRDMTest(unittest.TestCase):
         qubit_operator = jordan_wigner(self.hamiltonian)
         qubit_expectations = self.rdm.get_qubit_expectations(qubit_operator)
 
-        test_energy = qubit_operator.terms[()]
+        test_energy = 0.0
         for qubit_term in qubit_expectations.terms:
             term_coefficient = qubit_operator.terms[qubit_term]
             test_energy += (term_coefficient *

--- a/src/fermilib/tests/_hydrogen_integration_test.py
+++ b/src/fermilib/tests/_hydrogen_integration_test.py
@@ -193,7 +193,7 @@ class HydrogenIntegrationTest(unittest.TestCase):
 
         # Confirm expectation on qubit Hamiltonian using reverse JW matches.
         qubit_rdm = self.fci_rdm.get_qubit_expectations(self.qubit_hamiltonian)
-        qubit_energy = self.qubit_hamiltonian.terms[()]
+        qubit_energy = 0.0
         for term, expectation in qubit_rdm.terms.items():
             qubit_energy += expectation * self.qubit_hamiltonian.terms[term]
         self.assertAlmostEqual(qubit_energy, self.molecule.fci_energy)

--- a/src/fermilib/tests/_lih_integration_test.py
+++ b/src/fermilib/tests/_lih_integration_test.py
@@ -94,7 +94,7 @@ class LiHIntegrationTest(unittest.TestCase):
 
         # Confirm expectation on qubit Hamiltonian using reverse JW matches.
         qubit_rdm = self.fci_rdm.get_qubit_expectations(self.qubit_hamiltonian)
-        qubit_energy = self.qubit_hamiltonian.terms[()]
+        qubit_energy = 0.0
         for term, coefficient in qubit_rdm.terms.items():
             qubit_energy += coefficient * self.qubit_hamiltonian.terms[term]
         self.assertAlmostEqual(qubit_energy, self.molecule.fci_energy)


### PR DESCRIPTION
Interaction RDM's expectation functionality was out of date and contained some peculiar hold overs from previous QubitOperator format. In particular it removed the identity internally, which required one to add it externally.  Everything functions as expected if both of these removal/additions are removed at the same time.